### PR TITLE
#18 fix for dupping of items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ build.properties
 # Ignore build number #
 build.number
 /.project
+eclipse/
+bin/
+.gradle/
+.settings/

--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-version=0.5.4b
+version=0.5.5b
 forge_version=10.13.4.1492-1.7.10
 mc_version=1.7.10
 mod_name=XACT

--- a/changelog
+++ b/changelog
@@ -1,3 +1,11 @@
+v0.5.5b
+-------
+[*] fix for items stacks that have nbt data not being properly counted during crafting operations
+
+v0.5.5a
+-------
+[*] fix for hidden tile entity block being treated as an adjacent inventory
+
 v0.5.5
 ------
 [*] Fixed oredictionary problems with dyes

--- a/src/main/java/xk/xact/util/ItemsReference.java
+++ b/src/main/java/xk/xact/util/ItemsReference.java
@@ -75,10 +75,15 @@ public class ItemsReference {
 		if (this.itemDamage != reference.itemDamage)
 			return false;
 		
+		/* just checking enchantments is not good enough for some type of items
 		if (!Utils.compareEnchantments(this.stack, reference.stack))
 			return false;
+		*/
 		
-		return true;
+		// Compare stacks tags.
+		if (this.tag == null)
+			return reference.tag == null;
+		return this.tag.equals(reference.tag);
 	}
 	
 	public ItemStack toItemStack() {

--- a/src/main/java/xk/xact/util/Utils.java
+++ b/src/main/java/xk/xact/util/Utils.java
@@ -294,17 +294,17 @@ public class Utils {
 			return true;
 		return false;
 	}
-
+	
 	public static boolean compareEnchantments(ItemStack stack1, ItemStack stack2) {
 
 		if (stack1 == null || stack2 == null)
 			return false;
 
 		if (!stack1.hasTagCompound() && !stack2.hasTagCompound())
-			return true; // If both items don't have any nbt it'll just return
+			return false; // If both items don't have any nbt it'll just return
 							// true
 
-		if (!stack1.hasTagCompound() || !stack2.hasTagCompound())
+		if (!stack1.isItemEnchanted() || !stack2.isItemEnchanted())
 			return false; // If only one of the items has nbt it'll return false
 
 		if (stack1.getEnchantmentTagList().tagCount() > 0 && stack2.getEnchantmentTagList().tagCount() > 0) {


### PR DESCRIPTION
This fixes the issue when more than one of the same item is in the crafting grid and the item has nbt data. The required item count was not being calculated correctly and the crafting operation was using too few items.
